### PR TITLE
Fix for dataTransforms keys contained dot-notated keys.

### DIFF
--- a/lib/ModelMapper.js
+++ b/lib/ModelMapper.js
@@ -71,7 +71,8 @@ function mapAndTransform(dataObj, destObj, mappingConfig, reverse) {
         var value = accessors.getValue(dataObj, dataPath);
 
         // Check for a transformer for this newly-found value
-        var transformer = accessors.getValue(mappingConfig.dataTransforms, keyPath);
+        var transformer = _.get(mappingConfig.dataTransforms, keyPath);
+
         if (_.isFunction(transformer) && !_.isUndefined(value)) {
             value = transformer(value, reverse);
         }

--- a/test/testMapper.js
+++ b/test/testMapper.js
@@ -117,6 +117,34 @@ describe('ModelMapper', function () {
 
                 expect(myMapper.map(inputObject)).to.deep.equal(expectValue);
             });
+
+            it('when there\'s a dataTransforms section with nested property references', function () {
+                myMapper = new ModelMapper({
+                    dataMappings: {
+                        'a.c': 'a.b'
+                    },
+                    dataTransforms: {
+                        'a.c': function (value, reverse) {
+                            if (!reverse) {
+                                return value * 2;
+                            }
+                        }
+                    }
+                });
+                inputObject = {
+                    a: {
+                        b: 3
+                    }
+                };
+                var expectValue = {
+                    a: {
+                        c: 6
+                    }
+                };
+
+                expect(myMapper.map(inputObject)).to.deep.equal(expectValue);
+            });
+
         });
     });
 
@@ -162,6 +190,33 @@ describe('ModelMapper', function () {
                 });
                 inputObject = {
                     c: 6
+                };
+                var expectValue = {
+                    a: {
+                        b: 3
+                    }
+                };
+
+                expect(myMapper.mapReverse(inputObject)).to.deep.equal(expectValue);
+            });
+
+            it('when there\'s a dataTransforms section with nested property references', function () {
+                myMapper = new ModelMapper({
+                    dataMappings: {
+                        'a.c': 'a.b'
+                    },
+                    dataTransforms: {
+                        'a.c': function (value, reverse) {
+                            if (reverse) {
+                                return value / 2;
+                            }
+                        }
+                    }
+                });
+                inputObject = {
+                    a: {
+                        c: 6
+                    }
                 };
                 var expectValue = {
                     a: {


### PR DESCRIPTION
The issue is that when I attempt to register a data transformation (dataTransform) which references a nested property in the source object, the mapAndTransforms by passes the transform function on mapping.

```
    dataMappings: {
        'agentDetails.agencyPhoneNumbers': 'agentDetails.agencyPhoneNumbers',
        'agentDetails.agentPhoneNumbers': 'agentDetails.agentPhoneNumbers'
    },
    dataTransforms: {
        'agentDetails.agencyPhoneNumbers': mapperUtils.phoneNumberMapper,
        'agentDetails.agentPhoneNumbers': mapperUtils.phoneNumberMapper
    }
```

Changes include:
- updated ModelMapper.mapAndTransform() to used _.get instead of
  accessor.getValue
- test cases added to validate fix.
