### PR TITLE
Fix string to float util breaking if value is null

### DIFF
--- a/lib/mapperUtils.js
+++ b/lib/mapperUtils.js
@@ -46,7 +46,7 @@ function uppercaseWordsTransformer(stringVal, reverse) {
 
 function stringToFloatTransformer(val, reverse) {
     if (reverse) {
-        return (val !== null) ? val.toString() : val;
+        return (typeof val === 'number') ? val.toString() : undefined;
     } else {
         return parseFloat(val);
     }

--- a/lib/mapperUtils.js
+++ b/lib/mapperUtils.js
@@ -46,7 +46,7 @@ function uppercaseWordsTransformer(stringVal, reverse) {
 
 function stringToFloatTransformer(val, reverse) {
     if (reverse) {
-        return val.toString();
+        return (val !== null) ? val.toString() : val;
     } else {
         return parseFloat(val);
     }


### PR DESCRIPTION
If null is passed in, string to float transformer would break. This checks if val is null when going toString. If it is, the val is returned as is.